### PR TITLE
Add config file to load openAI key

### DIFF
--- a/code/config.json
+++ b/code/config.json
@@ -1,0 +1,3 @@
+{
+    "openai_key": "SET YOUR KEY HERE"
+}

--- a/code/get GNews.py
+++ b/code/get GNews.py
@@ -3,10 +3,15 @@
 import csv
 import datetime
 import openai
+import json
 from gnews import GNews
 from dateutil.tz import gettz
 
-openai.api_key = 'redacted'
+# Read the OpenAI API key from the config file
+with open('config.json', 'r') as file:
+    config = json.load(file)
+
+openai.api_key = config['openai_key']
 
 topics=['accident','political assassination','birth','political coup','volcano eruption','explosion','fire','game','religious miracle','shooting','suicide','wedding']
 


### PR DESCRIPTION
This makes it easier to separate the configuration properties of the application from the application code itself. Furthermore, you can re-use the keys in multiple files